### PR TITLE
Add live assessment key to .learn

### DIFF
--- a/.learn
+++ b/.learn
@@ -4,3 +4,4 @@ languages:
   - a language
 resources: 
   - 0
+live_assessment: true


### PR DESCRIPTION
@pletcher Haven't been able to look at this on Learn yet—but I'm guessing that it isn't rendering with the assessment right rail. Adding this key should take care of that.
